### PR TITLE
Update radiation.lua

### DIFF
--- a/mods/technic_plus/technic/radiation.lua
+++ b/mods/technic_plus/technic/radiation.lua
@@ -319,6 +319,9 @@ local function calculate_object_center(object)
 end
 
 local function dmg_object(pos, object, strength)
+	if not object or not object:get_pos() then
+		return
+	end
 	local obj_pos = vector.add(object:get_pos(), calculate_object_center(object))
 	local mul
 	if armor_enabled or entity_damage then


### PR DESCRIPTION
Fixing radiation crash ecki reported. It seems like the bug is related to minetest not being able to get objects position while its moving. 